### PR TITLE
Add get all session endpoint

### DIFF
--- a/src/controllers/sessionController.js
+++ b/src/controllers/sessionController.js
@@ -339,6 +339,30 @@ const requestPairingCode = async (req, res) => {
   }
 }
 
+/**
+ * Get all sessions.
+ *
+ * @function
+ * @async
+ * @param {Object} req - The HTTP request object.
+ * @param {Object} res - The HTTP response object.
+ * @returns {<Object>}
+ */
+const getSessions = async (req, res) => {
+  // #swagger.summary = 'Get all sessions'
+  // #swagger.description = 'Get all sessions.'
+  /* #swagger.responses[200] = {
+      description: "Retrieved all sessions.",
+      content: {
+        "application/json": {
+          schema: { "$ref": "#/definitions/GetSessionsResponse" }
+        }
+      }
+    }
+  */
+  return res.json({ success: true, result: Array.from(sessions.keys()) })
+}
+
 module.exports = {
   startSession,
   statusSession,
@@ -348,5 +372,6 @@ module.exports = {
   restartSession,
   terminateSession,
   terminateInactiveSessions,
-  terminateAllSessions
+  terminateAllSessions,
+  getSessions
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -36,6 +36,7 @@ sessionRouter.use(middleware.apikey)
 sessionRouter.use(middleware.sessionSwagger)
 routes.use('/session', sessionRouter)
 
+sessionRouter.get('/getSessions', sessionController.getSessions)
 sessionRouter.get('/start/:sessionId', middleware.sessionNameValidation, sessionController.startSession)
 sessionRouter.get('/status/:sessionId', middleware.sessionNameValidation, sessionController.statusSession)
 sessionRouter.get('/qr/:sessionId', middleware.sessionNameValidation, sessionController.sessionQrCode)

--- a/swagger.js
+++ b/swagger.js
@@ -72,6 +72,10 @@ const doc = {
     ForbiddenResponse: {
       success: false,
       error: 'Invalid API key'
+    },
+    GetSessionsResponse: {
+      success: true,
+      result: []
     }
   }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -106,6 +106,52 @@
         ]
       }
     },
+    "/session/getSessions": {
+      "get": {
+        "tags": [
+          "Session"
+        ],
+        "summary": "Get all sessions",
+        "description": "Get all sessions.",
+        "responses": {
+          "200": {
+            "description": "Retrieved all sessions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSessionsResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
     "/session/start/{sessionId}": {
       "get": {
         "tags": [
@@ -11068,6 +11114,23 @@
         },
         "xml": {
           "name": "ForbiddenResponse"
+        }
+      },
+      "GetSessionsResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "result": {
+            "type": "array",
+            "example": [],
+            "items": {}
+          }
+        },
+        "xml": {
+          "name": "GetSessionsResponse"
         }
       }
     },


### PR DESCRIPTION
Implementing the `/getSessions` endpoint to get all active sessions. 