### PR TITLE
chore: remove obsolete `version` attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     container_name: wwebjs_api


### PR DESCRIPTION
fixes warning:

> WARN[0000] ./docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
