### PR TITLE
feature(enhanced_media_support): override media from url filename

### DIFF
--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -81,6 +81,11 @@ const sendMessage = async (req, res) => {
         break
       case 'MessageMediaFromURL': {
         const messageMediaFromURL = await MessageMedia.fromUrl(content, { unsafeMime: true, ...mediaFromURLOptions })
+
+        if (options?.filename) {
+          messageMediaFromURL.filename = options.filename;
+        }
+
         messageOut = await client.sendMessage(chatId, messageMediaFromURL, options)
         break
       }


### PR DESCRIPTION
Sometimes you need to enforce the filename of a media file. 

When you serve files from a CDN, you usually add a hashed file name to ensure you will not overwrite any of the files on your bucket.

Let's say you want to send a media file with the URL `https://contabilizapro-prod.s3.sa-east-1.amazonaws.com/u_c927690c-2357-4c67-af9a-2b7d6d6ab0f5/15bb57a1-0c1b-4b01-87e0-6bcd40960c87.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAR6MREG3VUTRI4FXQ%2F20250321%2Fsa-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250321T203910Z&X-Amz-Expires=60&X-Amz-Signature=7d6011a27925ee6dbd8aca8d8d0a872ae16f15616c3d7a187179716c8439a8d6&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Ddummy.pdf.pdf&x-id=GetObject` (s3 public signed URL example), you will receive a file with a hashed file name, like this:

![image](https://github.com/user-attachments/assets/f7aa581d-306b-4e4f-a9be-8d6d4b20ea93)

That is really bad for the user experience, who will need to open the file to see what is. Overwriting the file name can help the user to identify the file without opening it.

This PR fixes that, and now the same URL above will send a file like this:

![image](https://github.com/user-attachments/assets/adb1c70f-1380-42f2-880c-46cfcb9dc5f4)

Request payload example

```
{
  "chatId": XXXXXXXXXXXc.us",
  "contentType": "MessageMediaFromURL",
  "content": "https://contabilizapro-prod.s3.sa-east-1.amazonaws.com/u_c927690c-2357-4c67-af9a-2b7d6d6ab0f5/15bb57a1-0c1b-4b01-87e0-6bcd40960c87.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAR6MREG3VUTRI4FXQ%2F20250321%2Fsa-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250321T204429Z&X-Amz-Expires=60&X-Amz-Signature=cc7c31d2824c5135b89118e56eea763c25d7ba9ed35d6c2d1f1be40dc8ef3013&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Ddummy.pdf.pdf&x-id=GetObject",
  "options": {
      "filename": "Awesome file I will remember.pdf",
      "caption": "Also support captions!"
  }
}
```
