### PR TITLE
feat(docs): unify response schema for the GetSessions endpoint

### DIFF
--- a/src/controllers/sessionController.js
+++ b/src/controllers/sessionController.js
@@ -397,12 +397,79 @@ const getSessions = async (req, res) => {
       description: "Retrieved all sessions.",
       content: {
         "application/json": {
-          schema: { "$ref": "#/definitions/GetSessionsResponse" }
+          schema: { "$ref": "#/definitions/GetSessionsResponse" },
+          examples: {
+            "Success": {
+              success: true,
+              result: ["sessionId1", "sessionId2", "sessionId3"],
+              message: "Retrieved all sessions.",
+            }
+          }
+        }
+      }
+    }
+
+    #swagger.responses[404] = {
+      description: "Not found.",
+      content: {
+        "application/json": {
+          schema: { "$ref": "#/definitions/GetSessionsResponse" },
+          examples: {
+            "Bad request": {
+              value: {
+                success: false,
+                result: [],
+                message: "Sessions not found"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    #swagger.responses[403] = {
+      description: "Forbidden",
+      content: {
+        "application/json": {
+          schema: { "$ref": "#/definitions/GetSessionsResponse" },
+          examples: {
+            "Forbidden": {
+              value: {
+                success: false,
+                result: [],
+                message: "Invalid API key"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    #swagger.responses[500] = {
+      description: "Internal Server Error.",
+      content: {
+        "application/json": {
+          schema: { "$ref": "#/definitions/GetSessionsResponse" },
+          examples: {
+            "Internal Server Error": {
+              value: {
+                success: false,
+                result: [],
+                message: "Internal Server Error."
+              }
+            }
+          }
         }
       }
     }
   */
-  return res.json({ success: true, result: Array.from(sessions.keys()) })
+
+  if(sessions.keys().length === 0) {
+    res.status(404)
+    return res.json({ success: false, result: [], message: 'Sessions not found' })
+  }
+ 
+  return res.json({ success: true, result: Array.from(sessions.keys()), message: 'Sessions retrieved successfully'})
 }
 
 /**

--- a/swagger.js
+++ b/swagger.js
@@ -79,7 +79,8 @@ const doc = {
     },
     GetSessionsResponse: {
       success: true,
-      result: ['session1', 'session2']
+      result: ['session1', 'session2'],
+      message: 'Sessions retrieved successfully'
     }
   }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -120,26 +120,74 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetSessionsResponse"
+                },
+                "examples": {
+                  "Success": {
+                    "success": true,
+                    "result": [
+                      "sessionId1",
+                      "sessionId2",
+                      "sessionId3"
+                    ],
+                    "message": "Retrieved all sessions."
+                  }
                 }
               }
             }
           },
           "403": {
-            "description": "Forbidden.",
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ForbiddenResponse"
+                  "$ref": "#/components/schemas/GetSessionsResponse"
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "success": false,
+                      "result": [],
+                      "message": "Invalid API key"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSessionsResponse"
+                },
+                "examples": {
+                  "Bad request": {
+                    "value": {
+                      "success": false,
+                      "result": [],
+                      "message": "Sessions not found"
+                    }
+                  }
                 }
               }
             }
           },
           "500": {
-            "description": "Server failure.",
+            "description": "Internal Server Error.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/GetSessionsResponse"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "value": {
+                      "success": false,
+                      "result": [],
+                      "message": "Internal Server Error."
+                    }
+                  }
                 }
               }
             }
@@ -15066,6 +15114,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "message": {
+            "type": "string",
+            "example": "Sessions retrieved successfully"
           }
         },
         "xml": {


### PR DESCRIPTION
feat(docs): unify response schema for the GetSessions endpoint

- Adopted a single predictable schema (GetSessionsResponse) for all endpoint responses
- Overrides the middleware's default documentation (403), ensuring consistent return types
- Added 404 response for when no sessions are found
- Added a success message in the response object
- Updates swagger documentation for 200, 404, 403, and 500 using the same schema
- Improves SDK consistency (nswag now generates only one response class)

autogenerated GetSessionsResponse in c# example

```cs
[System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.5.0.0 (NJsonSchema v11.4.0.0 (Newtonsoft.Json v13.0.0.0))")]
    public partial class GetSessionsResponse
    {

        [System.Text.Json.Serialization.JsonPropertyName("success")]
        public bool Success { get; set; }

        [System.Text.Json.Serialization.JsonPropertyName("result")]
        public System.Collections.Generic.ICollection<string> Result { get; set; }

        [System.Text.Json.Serialization.JsonPropertyName("message")]
        public string Message { get; set; }

        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;

        [System.Text.Json.Serialization.JsonExtensionData]
        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
        {
            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
            set { _additionalProperties = value; }
        }

    }
```