### PR TITLE
fix: Add sendSeen:false workaround for whatsapp-web.js #5718

### DIFF
--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -106,7 +106,8 @@ const sendMessage = async (req, res) => {
 
   try {
     const { chatId, content, contentType, options, mediaFromURLOptions = {} } = req.body
-    const sendOptions = { waitUntilMsgSent: true, ...options }
+    // sendSeen: false - workaround for whatsapp-web.js #5718 (markedUnread error)
+    const sendOptions = { waitUntilMsgSent: true, sendSeen: false, ...options }
     const client = sessions.get(req.params.sessionId)
     const chat = await client.getChatById(chatId)
     if (!chat) {

--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -66,7 +66,8 @@ const sendMessage = async (req, res) => {
   try {
     const { chatId, content, contentType, options = {}, mediaFromURLOptions = {} } = req.body
     const client = sessions.get(req.params.sessionId)
-    const sendOptions = { waitUntilMsgSent: true, ...options }
+    // sendSeen: false - workaround for whatsapp-web.js #5718 (markedUnread error)
+    const sendOptions = { waitUntilMsgSent: true, sendSeen: false, ...options }
 
     let messageOut
     switch (contentType) {

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -224,7 +224,8 @@ const forward = async (req, res) => {
     const client = sessions.get(req.params.sessionId)
     const message = await _getMessageById(client, messageId, chatId)
     if (!message) { throw new Error('Message not found') }
-    const result = await message.forward(destinationChatId)
+    // sendSeen: false - workaround for whatsapp-web.js #5718 (markedUnread error)
+    const result = await message.forward(destinationChatId, { sendSeen: false })
     res.json({ success: true, result })
   } catch (error) {
     sendErrorResponse(res, 500, error.message)
@@ -534,7 +535,9 @@ const reply = async (req, res) => {
       default:
         return sendErrorResponse(res, 400, 'contentType invalid, must be string, MessageMedia, MessageMediaFromURL, Location, Contact or Poll')
     }
-    const repliedMessage = await message.reply(contentMessage, chatId, options)
+    // sendSeen: false - workaround for whatsapp-web.js #5718 (markedUnread error)
+    const replyOptions = { sendSeen: false, ...options }
+    const repliedMessage = await message.reply(contentMessage, chatId, replyOptions)
     res.json({ success: true, repliedMessage })
   } catch (error) {
     sendErrorResponse(res, 500, error.message)


### PR DESCRIPTION
WhatsApp updated their web interface around Jan 14, 2026, breaking the sendSeen function. The library tries to access `message.markedUnread` property which no longer exists.

This fix bypasses the broken sendSeen by passing `sendSeen: false` to:
- client.sendMessage() in clientController.js
- chat.sendMessage() in channelController.js
- message.reply() in messageController.js
- message.forward() in messageController.js

References:
- https://github.com/pedroslopez/whatsapp-web.js/issues/5718