### PR TITLE
feat(docs): implement comprehensive Chat and ChatId schemas for Swagger

### DIFF
--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -348,8 +348,16 @@ const getContacts = async (req, res) => {
  * @throws {Error} If the operation fails, an error is thrown.
  */
 const getChats = async (req, res) => {
-  /*
-    #swagger.summary = 'Get all current chats'
+  /*  #swagger.summary = 'Get all current chats'
+    #swagger.description = 'Retrieve all chats for the given session ID.'
+    #swagger.responses[200] = {
+      description: 'Retrieved all chats.',
+      content: {
+        'application/json': {
+          schema: { "$ref": "#/definitions/GetChatsResponse" }
+        }
+      } 
+    }
   */
   try {
     const client = sessions.get(req.params.sessionId)
@@ -377,6 +385,7 @@ const getChats = async (req, res) => {
 const getChatsWithSearch = async (req, res) => {
   /*
     #swagger.summary = 'Get all current chats with optional search parameters'
+    #swagger.description = 'Retrieve all chats for the given session ID with optional search parameters.'
     #swagger.requestBody = {
       required: true,
       schema: {
@@ -398,6 +407,14 @@ const getChatsWithSearch = async (req, res) => {
           }
         }
       },
+    }
+    #swagger.responses[200] = {
+      description: 'Retrieved all chats with search parameters.',
+      content: {
+        'application/json': {
+          schema:  {"$ref": "#/definitions/GetChatsResponse"}
+        }
+      }
     }
   */
   try {

--- a/swagger.js
+++ b/swagger.js
@@ -85,6 +85,18 @@ const doc = {
       server: 'c.us | g.us',
       user: '1234567890',
       _serialized: '1234567890@c.us',
+    },
+    Chat: {
+      id: { $ref: '#/definitions/ChatId' },
+      name: 'John Doe',
+      isGroup: false, 
+      unreadCount: 0,
+      timestamp: 1770140061,
+      archived: false,
+      pinned: false,
+      isMuted: false,
+      muteExpiration: 0,
+      // Add other chat properties as needed after create definitions
     }
   }
 }

--- a/swagger.js
+++ b/swagger.js
@@ -97,6 +97,11 @@ const doc = {
       isMuted: false,
       muteExpiration: 0,
       // Add other chat properties as needed after create definitions
+    },
+    GetChatsResponse: {
+      success: true,
+      chats: [ { $ref: '#/definitions/Chat' } ],
+      error: 'error message if any',
     }
   }
 }

--- a/swagger.js
+++ b/swagger.js
@@ -80,6 +80,11 @@ const doc = {
     GetSessionsResponse: {
       success: true,
       result: ['session1', 'session2']
+    },
+    ChatId: {
+      server: 'c.us | g.us',
+      user: '1234567890',
+      _serialized: '1234567890@c.us',
     }
   }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -1541,7 +1541,7 @@
           "Client"
         ],
         "summary": "Get all current chats",
-        "description": "",
+        "description": "Retrieve all chats for the given session ID.",
         "parameters": [
           {
             "name": "sessionId",
@@ -1556,7 +1556,14 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Retrieved all chats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetChatsResponse"
+                }
+              }
+            }
           },
           "403": {
             "description": "Forbidden.",
@@ -1610,7 +1617,7 @@
           "Client"
         ],
         "summary": "Get all current chats with optional search parameters",
-        "description": "",
+        "description": "Retrieve all chats for the given session ID with optional search parameters.",
         "parameters": [
           {
             "name": "sessionId",
@@ -1625,7 +1632,14 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Retrieved all chats with search parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetChatsResponse"
+                }
+              }
+            }
           },
           "403": {
             "description": "Forbidden.",
@@ -15070,6 +15084,97 @@
         },
         "xml": {
           "name": "GetSessionsResponse"
+        }
+      },
+      "ChatId": {
+        "type": "object",
+        "properties": {
+          "server": {
+            "type": "string",
+            "example": "c.us | g.us"
+          },
+          "user": {
+            "type": "string",
+            "example": "1234567890"
+          },
+          "_serialized": {
+            "type": "string",
+            "example": "1234567890@c.us"
+          }
+        },
+        "xml": {
+          "name": "ChatId"
+        }
+      },
+      "Chat": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "xml": {
+              "name": "chatid"
+            },
+            "$ref": "#/components/schemas/ChatId"
+          },
+          "name": {
+            "type": "string",
+            "example": "John Doe"
+          },
+          "isGroup": {
+            "type": "boolean",
+            "example": false
+          },
+          "unreadCount": {
+            "type": "number",
+            "example": 0
+          },
+          "timestamp": {
+            "type": "number",
+            "example": 1770140061
+          },
+          "archived": {
+            "type": "boolean",
+            "example": false
+          },
+          "pinned": {
+            "type": "boolean",
+            "example": false
+          },
+          "isMuted": {
+            "type": "boolean",
+            "example": false
+          },
+          "muteExpiration": {
+            "type": "number",
+            "example": 0
+          }
+        },
+        "xml": {
+          "name": "Chat"
+        }
+      },
+      "GetChatsResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "chats": {
+            "type": "array",
+            "items": {
+              "xml": {
+                "name": "chat"
+              },
+              "$ref": "#/components/schemas/Chat"
+            }
+          },
+          "error": {
+            "type": "string",
+            "example": "error message if any"
+          }
+        },
+        "xml": {
+          "name": "GetChatsResponse"
         }
       }
     },


### PR DESCRIPTION
## 📚 API Documentation Enhancement – Chat Schemas

This PR improves the API documentation by introducing explicit schemas for chat-related responses. As a result, the Swagger UI now accurately represents the data structures used in WhatsApp chat management.

---

### ✅ Changes

- **Schema Definitions**  
  Added the following schemas to `swagger.js` and `swagger.json`:
  - `ChatId`
  - `Chat`
  - `GetChatsResponse`

- **Controller Integration**  
  Updated `getChats` and `getChatsWithSearch` in `clientController.js` to leverage the new `$ref` schema definitions.

- **Documentation Clarity**  
  Refined endpoint descriptions related to chat retrieval, clearly specifying session-based behavior.

---

### 🚀 Impact

- Provides clear and consistent expectations for the `Chat` object structure, including:
  - `unreadCount`
  - `isGroup`
  - Serialized `ChatId`

---

### ⚠️ Important Note on `Chat` Schema

> **[!IMPORTANT]**  
> The current `Chat` schema represents a **base version**.  
> The `lastMessage` property and its associated nested models will be added in a future PR, once the required message schemas are finalized.
