### PR TITLE
feat: dynamic webhook URL per session

### DIFF
--- a/src/controllers/sessionController.js
+++ b/src/controllers/sessionController.js
@@ -1,5 +1,5 @@
 const qr = require('qr-image')
-const { setupSession, deleteSession, reloadSession, validateSession, flushSessions, destroySession, sessions } = require('../sessions')
+const { setupSession, deleteSession, reloadSession, validateSession, flushSessions, destroySession, sessions, setSessionWebhook, getSessionWebhook } = require('../sessions')
 const { sendErrorResponse, waitForNestedObject, exposeFunctionIfAbsent } = require('../utils')
 const { logger } = require('../logger')
 
@@ -11,15 +11,37 @@ const { logger } = require('../logger')
  * @param {Object} req - The HTTP request object.
  * @param {Object} res - The HTTP response object.
  * @param {string} req.params.sessionId - The session ID to start.
+ * @param {string} [req.body.webhookUrl] - Optional webhook URL for this session.
  * @returns {Promise<void>}
  * @throws {Error} If there was an error starting the session.
  */
 const startSession = async (req, res) => {
   // #swagger.summary = 'Start new session'
-  // #swagger.description = 'Starts a session for the given session ID.'
+  // #swagger.description = 'Starts a session for the given session ID. Optionally accepts a webhookUrl in the request body (POST) to configure a per-session webhook.'
+  /*
+    #swagger.requestBody = {
+      required: false,
+      schema: {
+        type: 'object',
+        properties: {
+          webhookUrl: {
+            type: 'string',
+            description: 'Optional webhook URL for this session. Overrides BASE_WEBHOOK_URL and session env var.',
+            example: 'https://your-server.com/webhook/my-session'
+          }
+        }
+      }
+    }
+  */
   const sessionId = req.params.sessionId
   try {
-    const setupSessionReturn = await setupSession(sessionId)
+    // Read optional webhookUrl from body (works for both GET with empty body and POST with JSON)
+    const options = {}
+    if (req.body && req.body.webhookUrl) {
+      options.webhookUrl = req.body.webhookUrl
+    }
+
+    const setupSessionReturn = await setupSession(sessionId, options)
     if (!setupSessionReturn.success) {
       /* #swagger.responses[422] = {
         description: "Unprocessable Entity.",
@@ -47,6 +69,107 @@ const startSession = async (req, res) => {
     res.json({ success: true, message: setupSessionReturn.message })
   } catch (error) {
     logger.error({ sessionId, err: error }, 'Failed to start session')
+    sendErrorResponse(res, 500, error.message)
+  }
+}
+
+/**
+ * Set or update the webhook URL for an active session.
+ *
+ * @function
+ * @async
+ * @param {Object} req - The HTTP request object.
+ * @param {Object} res - The HTTP response object.
+ * @param {string} req.params.sessionId - The session ID.
+ * @param {string} req.body.webhookUrl - The new webhook URL (or null/empty to clear).
+ * @returns {Promise<void>}
+ */
+const setWebhook = async (req, res) => {
+  // #swagger.summary = 'Set session webhook URL'
+  // #swagger.description = 'Set or update the webhook URL for an active session at runtime. Send an empty webhookUrl or null to clear and fall back to environment variables.'
+  /*
+    #swagger.requestBody = {
+      required: true,
+      schema: {
+        type: 'object',
+        properties: {
+          webhookUrl: {
+            type: 'string',
+            description: 'The webhook URL to set for this session. Send empty string or null to clear.',
+            example: 'https://your-server.com/webhook/my-session'
+          }
+        }
+      }
+    }
+  */
+  const sessionId = req.params.sessionId
+  try {
+    const { webhookUrl } = req.body || {}
+    const result = setSessionWebhook(sessionId, webhookUrl)
+    if (!result.success) {
+      return sendErrorResponse(res, 404, result.message)
+    }
+    /* #swagger.responses[200] = {
+      description: "Webhook URL updated.",
+      content: {
+        "application/json": {
+          schema: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              message: { type: 'string' },
+              webhookUrl: { type: 'string' }
+            }
+          }
+        }
+      }
+    }
+    */
+    res.json(result)
+  } catch (error) {
+    logger.error({ sessionId, err: error }, 'Failed to set session webhook')
+    sendErrorResponse(res, 500, error.message)
+  }
+}
+
+/**
+ * Get the current webhook URL for a session.
+ *
+ * @function
+ * @async
+ * @param {Object} req - The HTTP request object.
+ * @param {Object} res - The HTTP response object.
+ * @param {string} req.params.sessionId - The session ID.
+ * @returns {Promise<void>}
+ */
+const getWebhook = async (req, res) => {
+  // #swagger.summary = 'Get session webhook URL'
+  // #swagger.description = 'Get the current webhook URL for a session, including the source (runtime, env_session, env_global, or none).'
+  const sessionId = req.params.sessionId
+  try {
+    const result = getSessionWebhook(sessionId)
+    if (!result.success) {
+      return sendErrorResponse(res, 404, result.message)
+    }
+    /* #swagger.responses[200] = {
+      description: "Current webhook URL and source.",
+      content: {
+        "application/json": {
+          schema: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              webhookUrl: { type: 'string' },
+              source: { type: 'string', enum: ['runtime', 'env_session', 'env_global', 'none'] }
+            }
+          }
+        }
+      }
+    }
+    */
+    res.json(result)
+  } catch (error) {
+    logger.error({ sessionId, err: error }, 'Failed to get session webhook')
     sendErrorResponse(res, 500, error.message)
   }
 }
@@ -465,5 +588,7 @@ module.exports = {
   terminateInactiveSessions,
   terminateAllSessions,
   getSessions,
-  getPageScreenshot
+  getPageScreenshot,
+  setWebhook,
+  getWebhook
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -39,6 +39,7 @@ routes.use('/session', sessionRouter)
 
 sessionRouter.get('/getSessions', sessionController.getSessions)
 sessionRouter.get('/start/:sessionId', middleware.sessionNameValidation, sessionController.startSession)
+sessionRouter.post('/start/:sessionId', middleware.sessionNameValidation, sessionController.startSession)
 sessionRouter.get('/stop/:sessionId', middleware.sessionNameValidation, sessionController.stopSession)
 sessionRouter.get('/status/:sessionId', middleware.sessionNameValidation, sessionController.statusSession)
 sessionRouter.get('/qr/:sessionId', middleware.sessionNameValidation, sessionController.sessionQrCode)
@@ -49,6 +50,8 @@ sessionRouter.get('/terminate/:sessionId', middleware.sessionNameValidation, ses
 sessionRouter.get('/terminateInactive', sessionController.terminateInactiveSessions)
 sessionRouter.get('/terminateAll', sessionController.terminateAllSessions)
 sessionRouter.get('/getPageScreenshot/:sessionId', middleware.sessionNameValidation, sessionController.getPageScreenshot)
+sessionRouter.put('/setWebhook/:sessionId', middleware.sessionNameValidation, sessionController.setWebhook)
+sessionRouter.get('/getWebhook/:sessionId', middleware.sessionNameValidation, sessionController.getWebhook)
 
 /**
  * ================

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -85,7 +85,7 @@ const restoreSessions = () => {
 }
 
 // Setup Session
-const setupSession = async (sessionId) => {
+const setupSession = async (sessionId, options = {}) => {
   try {
     if (sessions.has(sessionId)) {
       return { success: false, message: `Session already exists for: ${sessionId}`, client: sessions.get(sessionId) }
@@ -166,6 +166,13 @@ const setupSession = async (sessionId) => {
     }
 
     const client = new Client(clientOptions)
+
+    // Store custom webhook URL on client if provided
+    if (options.webhookUrl) {
+      client.webhookUrl = options.webhookUrl
+      logger.info({ sessionId, webhookUrl: options.webhookUrl }, 'Custom webhook URL configured for session')
+    }
+
     if (releaseBrowserLock) {
       // See https://github.com/puppeteer/puppeteer/issues/4860
       const singletonLockPath = path.resolve(path.join(sessionFolderPath, `session-${sessionId}`, 'SingletonLock'))
@@ -198,16 +205,45 @@ const setupSession = async (sessionId) => {
   }
 }
 
+// Function to set webhook URL for an active session at runtime
+const setSessionWebhook = (sessionId, webhookUrl) => {
+  const client = sessions.get(sessionId)
+  if (!client) {
+    return { success: false, message: 'session_not_found' }
+  }
+  client.webhookUrl = webhookUrl || null
+  logger.info({ sessionId, webhookUrl: webhookUrl || '(cleared, using default)' }, 'Session webhook URL updated')
+  return { success: true, message: 'Webhook URL updated successfully', webhookUrl: client.webhookUrl }
+}
+
+// Function to get webhook URL for an active session
+const getSessionWebhook = (sessionId) => {
+  const client = sessions.get(sessionId)
+  if (!client) {
+    return { success: false, message: 'session_not_found' }
+  }
+  const envWebhook = process.env[sessionId.toUpperCase() + '_WEBHOOK_URL']
+  return {
+    success: true,
+    webhookUrl: client.webhookUrl || envWebhook || baseWebhookURL || null,
+    source: client.webhookUrl ? 'runtime' : (envWebhook ? 'env_session' : (baseWebhookURL ? 'env_global' : 'none'))
+  }
+}
+
 const initializeEvents = (client, sessionId) => {
-  // check if the session webhook is overridden
-  const sessionWebhook = process.env[sessionId.toUpperCase() + '_WEBHOOK_URL'] || baseWebhookURL
+  // Priority: runtime webhookUrl > session env var > global env var
+  const getWebhookUrl = () => {
+    return client.webhookUrl || process.env[sessionId.toUpperCase() + '_WEBHOOK_URL'] || baseWebhookURL
+  }
 
   if (recoverSessions) {
     waitForNestedObject(client, 'pupPage').then(() => {
       const restartSession = async (sessionId) => {
+        // Preserve webhook URL across restarts
+        const savedWebhookUrl = client.webhookUrl
         sessions.delete(sessionId)
         await client.destroy().catch(e => { })
-        await setupSession(sessionId)
+        await setupSession(sessionId, { webhookUrl: savedWebhookUrl })
       }
       client.pupPage.once('close', function () {
         // emitted when the page closes
@@ -238,7 +274,7 @@ const initializeEvents = (client, sessionId) => {
 
   if (isEventEnabled('auth_failure')) {
     client.on('auth_failure', (msg) => {
-      triggerWebhook(sessionWebhook, sessionId, 'status', { msg })
+      triggerWebhook(getWebhookUrl(), sessionId, 'status', { msg })
       triggerWebSocket(sessionId, 'status', { msg })
     })
   }
@@ -246,90 +282,90 @@ const initializeEvents = (client, sessionId) => {
   client.on('authenticated', () => {
     client.qr = null
     if (isEventEnabled('authenticated')) {
-      triggerWebhook(sessionWebhook, sessionId, 'authenticated')
+      triggerWebhook(getWebhookUrl(), sessionId, 'authenticated')
       triggerWebSocket(sessionId, 'authenticated')
     }
   })
 
   if (isEventEnabled('call')) {
     client.on('call', (call) => {
-      triggerWebhook(sessionWebhook, sessionId, 'call', { call })
+      triggerWebhook(getWebhookUrl(), sessionId, 'call', { call })
       triggerWebSocket(sessionId, 'call', { call })
     })
   }
 
   if (isEventEnabled('change_state')) {
     client.on('change_state', state => {
-      triggerWebhook(sessionWebhook, sessionId, 'change_state', { state })
+      triggerWebhook(getWebhookUrl(), sessionId, 'change_state', { state })
       triggerWebSocket(sessionId, 'change_state', { state })
     })
   }
 
   if (isEventEnabled('disconnected')) {
     client.on('disconnected', (reason) => {
-      triggerWebhook(sessionWebhook, sessionId, 'disconnected', { reason })
+      triggerWebhook(getWebhookUrl(), sessionId, 'disconnected', { reason })
       triggerWebSocket(sessionId, 'disconnected', { reason })
     })
   }
 
   if (isEventEnabled('group_join')) {
     client.on('group_join', (notification) => {
-      triggerWebhook(sessionWebhook, sessionId, 'group_join', { notification })
+      triggerWebhook(getWebhookUrl(), sessionId, 'group_join', { notification })
       triggerWebSocket(sessionId, 'group_join', { notification })
     })
   }
 
   if (isEventEnabled('group_leave')) {
     client.on('group_leave', (notification) => {
-      triggerWebhook(sessionWebhook, sessionId, 'group_leave', { notification })
+      triggerWebhook(getWebhookUrl(), sessionId, 'group_leave', { notification })
       triggerWebSocket(sessionId, 'group_leave', { notification })
     })
   }
 
   if (isEventEnabled('group_admin_changed')) {
     client.on('group_admin_changed', (notification) => {
-      triggerWebhook(sessionWebhook, sessionId, 'group_admin_changed', { notification })
+      triggerWebhook(getWebhookUrl(), sessionId, 'group_admin_changed', { notification })
       triggerWebSocket(sessionId, 'group_admin_changed', { notification })
     })
   }
 
   if (isEventEnabled('group_membership_request')) {
     client.on('group_membership_request', (notification) => {
-      triggerWebhook(sessionWebhook, sessionId, 'group_membership_request', { notification })
+      triggerWebhook(getWebhookUrl(), sessionId, 'group_membership_request', { notification })
       triggerWebSocket(sessionId, 'group_membership_request', { notification })
     })
   }
 
   if (isEventEnabled('group_update')) {
     client.on('group_update', (notification) => {
-      triggerWebhook(sessionWebhook, sessionId, 'group_update', { notification })
+      triggerWebhook(getWebhookUrl(), sessionId, 'group_update', { notification })
       triggerWebSocket(sessionId, 'group_update', { notification })
     })
   }
 
   if (isEventEnabled('loading_screen')) {
     client.on('loading_screen', (percent, message) => {
-      triggerWebhook(sessionWebhook, sessionId, 'loading_screen', { percent, message })
+      triggerWebhook(getWebhookUrl(), sessionId, 'loading_screen', { percent, message })
       triggerWebSocket(sessionId, 'loading_screen', { percent, message })
     })
   }
 
   if (isEventEnabled('media_uploaded')) {
     client.on('media_uploaded', (message) => {
-      triggerWebhook(sessionWebhook, sessionId, 'media_uploaded', { message })
+      triggerWebhook(getWebhookUrl(), sessionId, 'media_uploaded', { message })
       triggerWebSocket(sessionId, 'media_uploaded', { message })
     })
   }
 
   client.on('message', async (message) => {
     if (isEventEnabled('message')) {
-      triggerWebhook(sessionWebhook, sessionId, 'message', { message })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message', { message })
       triggerWebSocket(sessionId, 'message', { message })
       if (message.hasMedia && message._data?.size < maxAttachmentSize) {
       // custom service event
         if (isEventEnabled('media')) {
           message.downloadMedia().then(messageMedia => {
-            triggerWebhook(sessionWebhook, sessionId, 'media', { messageMedia, message })
+            triggerWebhook(getWebhookUrl(), sessionId, 'media', { messageMedia, message })
             triggerWebSocket(sessionId, 'media', { messageMedia, message })
           }).catch(error => {
             logger.error({ sessionId, err: error }, 'Failed to download media')
@@ -346,49 +382,49 @@ const initializeEvents = (client, sessionId) => {
 
   if (isEventEnabled('message_ack')) {
     client.on('message_ack', (message, ack) => {
-      triggerWebhook(sessionWebhook, sessionId, 'message_ack', { message, ack })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message_ack', { message, ack })
       triggerWebSocket(sessionId, 'message_ack', { message, ack })
     })
   }
 
   if (isEventEnabled('message_create')) {
     client.on('message_create', (message) => {
-      triggerWebhook(sessionWebhook, sessionId, 'message_create', { message })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message_create', { message })
       triggerWebSocket(sessionId, 'message_create', { message })
     })
   }
 
   if (isEventEnabled('message_reaction')) {
     client.on('message_reaction', (reaction) => {
-      triggerWebhook(sessionWebhook, sessionId, 'message_reaction', { reaction })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message_reaction', { reaction })
       triggerWebSocket(sessionId, 'message_reaction', { reaction })
     })
   }
 
   if (isEventEnabled('message_edit')) {
     client.on('message_edit', (message, newBody, prevBody) => {
-      triggerWebhook(sessionWebhook, sessionId, 'message_edit', { message, newBody, prevBody })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message_edit', { message, newBody, prevBody })
       triggerWebSocket(sessionId, 'message_edit', { message, newBody, prevBody })
     })
   }
 
   if (isEventEnabled('message_ciphertext')) {
     client.on('message_ciphertext', (message) => {
-      triggerWebhook(sessionWebhook, sessionId, 'message_ciphertext', { message })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message_ciphertext', { message })
       triggerWebSocket(sessionId, 'message_ciphertext', { message })
     })
   }
 
   if (isEventEnabled('message_revoke_everyone')) {
     client.on('message_revoke_everyone', (message) => {
-      triggerWebhook(sessionWebhook, sessionId, 'message_revoke_everyone', { message })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message_revoke_everyone', { message })
       triggerWebSocket(sessionId, 'message_revoke_everyone', { message })
     })
   }
 
   if (isEventEnabled('message_revoke_me')) {
     client.on('message_revoke_me', (message, revokedMsg) => {
-      triggerWebhook(sessionWebhook, sessionId, 'message_revoke_me', { message, revokedMsg })
+      triggerWebhook(getWebhookUrl(), sessionId, 'message_revoke_me', { message, revokedMsg })
       triggerWebSocket(sessionId, 'message_revoke_me', { message, revokedMsg })
     })
   }
@@ -397,56 +433,56 @@ const initializeEvents = (client, sessionId) => {
     // inject qr code into session
     client.qr = qr
     if (isEventEnabled('qr')) {
-      triggerWebhook(sessionWebhook, sessionId, 'qr', { qr })
+      triggerWebhook(getWebhookUrl(), sessionId, 'qr', { qr })
       triggerWebSocket(sessionId, 'qr', { qr })
     }
   })
 
   if (isEventEnabled('ready')) {
     client.on('ready', () => {
-      triggerWebhook(sessionWebhook, sessionId, 'ready')
+      triggerWebhook(getWebhookUrl(), sessionId, 'ready')
       triggerWebSocket(sessionId, 'ready')
     })
   }
 
   if (isEventEnabled('contact_changed')) {
     client.on('contact_changed', (message, oldId, newId, isContact) => {
-      triggerWebhook(sessionWebhook, sessionId, 'contact_changed', { message, oldId, newId, isContact })
+      triggerWebhook(getWebhookUrl(), sessionId, 'contact_changed', { message, oldId, newId, isContact })
       triggerWebSocket(sessionId, 'contact_changed', { message, oldId, newId, isContact })
     })
   }
 
   if (isEventEnabled('chat_removed')) {
     client.on('chat_removed', (chat) => {
-      triggerWebhook(sessionWebhook, sessionId, 'chat_removed', { chat })
+      triggerWebhook(getWebhookUrl(), sessionId, 'chat_removed', { chat })
       triggerWebSocket(sessionId, 'chat_removed', { chat })
     })
   }
 
   if (isEventEnabled('chat_archived')) {
     client.on('chat_archived', (chat, currState, prevState) => {
-      triggerWebhook(sessionWebhook, sessionId, 'chat_archived', { chat, currState, prevState })
+      triggerWebhook(getWebhookUrl(), sessionId, 'chat_archived', { chat, currState, prevState })
       triggerWebSocket(sessionId, 'chat_archived', { chat, currState, prevState })
     })
   }
 
   if (isEventEnabled('unread_count')) {
     client.on('unread_count', (chat) => {
-      triggerWebhook(sessionWebhook, sessionId, 'unread_count', { chat })
+      triggerWebhook(getWebhookUrl(), sessionId, 'unread_count', { chat })
       triggerWebSocket(sessionId, 'unread_count', { chat })
     })
   }
 
   if (isEventEnabled('vote_update')) {
     client.on('vote_update', (vote) => {
-      triggerWebhook(sessionWebhook, sessionId, 'vote_update', { vote })
+      triggerWebhook(getWebhookUrl(), sessionId, 'vote_update', { vote })
       triggerWebSocket(sessionId, 'vote_update', { vote })
     })
   }
 
   if (isEventEnabled('code')) {
     client.on('code', (code) => {
-      triggerWebhook(sessionWebhook, sessionId, 'code', { code })
+      triggerWebhook(getWebhookUrl(), sessionId, 'code', { code })
       triggerWebSocket(sessionId, 'code', { code })
     })
   }
@@ -480,6 +516,8 @@ const reloadSession = async (sessionId) => {
     if (!client) {
       return
     }
+    // Preserve webhook URL across reloads
+    const savedWebhookUrl = client.webhookUrl
     client.pupPage?.removeAllListeners('close')
     client.pupPage?.removeAllListeners('error')
     try {
@@ -496,7 +534,7 @@ const reloadSession = async (sessionId) => {
       }
     }
     sessions.delete(sessionId)
-    await setupSession(sessionId)
+    await setupSession(sessionId, { webhookUrl: savedWebhookUrl })
   } catch (error) {
     logger.error({ sessionId, err: error }, 'Failed to reload session')
     throw error
@@ -597,5 +635,7 @@ module.exports = {
   deleteSession,
   reloadSession,
   flushSessions,
-  destroySession
+  destroySession,
+  setSessionWebhook,
+  getSessionWebhook
 }

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -7,6 +7,56 @@ const { triggerWebhook, waitForNestedObject, isEventEnabled, sendMessageSeenStat
 const { logger } = require('./logger')
 const { initWebSocketServer, terminateWebSocketServer, triggerWebSocket } = require('./websocket')
 
+// ═══════════════════════════════════════════════════════════════════
+// Webhook Config Persistence
+// ═══════════════════════════════════════════════════════════════════
+
+const getWebhookConfigPath = (sessionId) => {
+  return path.join(sessionFolderPath, `session-${sessionId}`, 'webhook_config.json')
+}
+
+const saveWebhookConfig = async (sessionId, webhookUrl) => {
+  try {
+    const configPath = getWebhookConfigPath(sessionId)
+    const dirPath = path.dirname(configPath)
+    if (!fs.existsSync(dirPath)) {
+      return // Session folder doesn't exist yet, will be saved after session starts
+    }
+    if (webhookUrl) {
+      await fs.promises.writeFile(configPath, JSON.stringify({ webhookUrl }, null, 2))
+      logger.debug({ sessionId }, 'Webhook config saved to disk')
+    } else {
+      // Clear the config file if webhookUrl is null/empty
+      if (fs.existsSync(configPath)) {
+        await fs.promises.unlink(configPath)
+        logger.debug({ sessionId }, 'Webhook config removed from disk')
+      }
+    }
+  } catch (error) {
+    logger.error({ sessionId, err: error }, 'Failed to save webhook config')
+  }
+}
+
+const loadWebhookConfig = (sessionId) => {
+  try {
+    const configPath = getWebhookConfigPath(sessionId)
+    if (fs.existsSync(configPath)) {
+      const data = JSON.parse(fs.readFileSync(configPath, 'utf8'))
+      if (data && data.webhookUrl) {
+        logger.info({ sessionId, webhookUrl: data.webhookUrl }, 'Webhook config loaded from disk')
+        return data.webhookUrl
+      }
+    }
+  } catch (error) {
+    logger.error({ sessionId, err: error }, 'Failed to load webhook config')
+  }
+  return null
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Session Validation
+// ═══════════════════════════════════════════════════════════════════
+
 // Function to validate if the session is ready
 const validateSession = async (sessionId) => {
   try {
@@ -60,6 +110,10 @@ const validateSession = async (sessionId) => {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════════
+// Session Management
+// ═══════════════════════════════════════════════════════════════════
+
 // Function to handle client session restoration
 const restoreSessions = () => {
   try {
@@ -75,7 +129,9 @@ const restoreSessions = () => {
         if (match) {
           const sessionId = match[1]
           logger.warn({ sessionId }, 'Existing session detected')
-          await setupSession(sessionId)
+          // Load persisted webhook config if available
+          const savedWebhookUrl = loadWebhookConfig(sessionId)
+          await setupSession(sessionId, savedWebhookUrl ? { webhookUrl: savedWebhookUrl } : {})
         }
       }
     })
@@ -167,7 +223,7 @@ const setupSession = async (sessionId, options = {}) => {
 
     const client = new Client(clientOptions)
 
-    // Store custom webhook URL on client if provided
+    // Store custom webhook URL on client if provided via API or loaded from disk
     if (options.webhookUrl) {
       client.webhookUrl = options.webhookUrl
       logger.info({ sessionId, webhookUrl: options.webhookUrl }, 'Custom webhook URL configured for session')
@@ -188,6 +244,10 @@ const setupSession = async (sessionId, options = {}) => {
         patchWWebLibrary(client).catch((err) => {
           logger.error({ sessionId, err }, 'Failed to patch WWebJS library')
         })
+        // Persist webhook config to disk once session folder is ready
+        if (options.webhookUrl) {
+          saveWebhookConfig(sessionId, options.webhookUrl)
+        }
       })
       initWebSocketServer(sessionId)
       initializeEvents(client, sessionId)
@@ -205,6 +265,10 @@ const setupSession = async (sessionId, options = {}) => {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════════
+// Webhook Management
+// ═══════════════════════════════════════════════════════════════════
+
 // Function to set webhook URL for an active session at runtime
 const setSessionWebhook = (sessionId, webhookUrl) => {
   const client = sessions.get(sessionId)
@@ -212,6 +276,8 @@ const setSessionWebhook = (sessionId, webhookUrl) => {
     return { success: false, message: 'session_not_found' }
   }
   client.webhookUrl = webhookUrl || null
+  // Persist to disk so it survives server restarts
+  saveWebhookConfig(sessionId, webhookUrl)
   logger.info({ sessionId, webhookUrl: webhookUrl || '(cleared, using default)' }, 'Session webhook URL updated')
   return { success: true, message: 'Webhook URL updated successfully', webhookUrl: client.webhookUrl }
 }
@@ -230,6 +296,10 @@ const getSessionWebhook = (sessionId) => {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════════
+// Event Initialization
+// ═══════════════════════════════════════════════════════════════════
+
 const initializeEvents = (client, sessionId) => {
   // Priority: runtime webhookUrl > session env var > global env var
   const getWebhookUrl = () => {
@@ -239,7 +309,7 @@ const initializeEvents = (client, sessionId) => {
   if (recoverSessions) {
     waitForNestedObject(client, 'pupPage').then(() => {
       const restartSession = async (sessionId) => {
-        // Preserve webhook URL across restarts
+        // Preserve webhook URL across restarts (also persisted on disk)
         const savedWebhookUrl = client.webhookUrl
         sessions.delete(sessionId)
         await client.destroy().catch(e => { })
@@ -488,6 +558,10 @@ const initializeEvents = (client, sessionId) => {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════════
+// Session Cleanup
+// ═══════════════════════════════════════════════════════════════════
+
 // Function to delete client session folder
 const deleteSessionFolder = async (sessionId) => {
   try {
@@ -516,7 +590,7 @@ const reloadSession = async (sessionId) => {
     if (!client) {
       return
     }
-    // Preserve webhook URL across reloads
+    // Preserve webhook URL across reloads (also persisted on disk)
     const savedWebhookUrl = client.webhookUrl
     client.pupPage?.removeAllListeners('close')
     client.pupPage?.removeAllListeners('error')


### PR DESCRIPTION
## Summary

Implements the feature proposed in #34 — dynamic webhook URL configuration per session, without requiring environment variables or server restarts.

### Changes

**`src/sessions.js`**
- `setupSession(sessionId, options)` now accepts an optional `options.webhookUrl` parameter
- Webhook URL is stored in-memory on the client object (`client.webhookUrl`)
- `initializeEvents` uses a `getWebhookUrl()` closure that resolves at call time: `client.webhookUrl → env session var → BASE_WEBHOOK_URL`
- Webhook URL is preserved across session restarts and reloads
- **Webhook URL is persisted to disk** (`session-{id}/webhook_config.json`) so it survives server restarts
- `restoreSessions` loads persisted webhook config when restoring sessions
- New exported functions: `setSessionWebhook()`, `getSessionWebhook()`

**`src/controllers/sessionController.js`**
- `startSession` reads optional `webhookUrl` from `req.body` (works with both GET for backward compat and POST with JSON body)
- New `setWebhook` controller to update webhook URL at runtime
- New `getWebhook` controller to retrieve current webhook URL and its source (`runtime`, `env_session`, `env_global`, `none`)

**`src/routes.js`**
- Added `POST /session/start/:sessionId` (accepts `webhookUrl` in body) alongside existing `GET` route
- Added `PUT /session/setWebhook/:sessionId` — update webhook URL at runtime
- Added `GET /session/getWebhook/:sessionId` — get current webhook URL and source

### Backward Compatibility

- **Zero breaking changes**: `GET /session/start/:sessionId` still works exactly as before
- If no `webhookUrl` is provided, behavior is identical to current: env session var → `BASE_WEBHOOK_URL`
- All existing environment variable configuration continues to work as fallback

### Persistence

Webhook URLs configured via API are persisted to `session-{id}/webhook_config.json` inside the session folder. This means:
- **Server restarts**: When `AUTO_START_SESSIONS=true`, restored sessions will reload their webhook URLs from disk
- **Session restarts/reloads**: Webhook URL is preserved in-memory and on disk
- **Session terminate**: The `webhook_config.json` is deleted along with the session folder
- **Clearing webhook**: Sending empty/null `webhookUrl` removes the config file, falling back to env vars

### Usage Examples

**Start session with webhook:**
```bash
curl -X POST http://localhost:3000/session/start/my-session \
  -H "Content-Type: application/json" \
  -d '{"webhookUrl": "https://my-n8n.com/webhook/abc123"}'
```

**Update webhook URL at runtime:**
```bash
curl -X PUT http://localhost:3000/session/setWebhook/my-session \
  -H "Content-Type: application/json" \
  -d '{"webhookUrl": "https://my-n8n.com/webhook/new-url"}'
```

**Check current webhook:**
```bash
curl http://localhost:3000/session/getWebhook/my-session
# {"success":true,"webhookUrl":"https://...","source":"runtime"}
```

### Priority Resolution

```
1. client.webhookUrl (set via API, persisted to disk)  ← NEW
2. process.env[SESSIONID_WEBHOOK_URL]                  ← existing
3. BASE_WEBHOOK_URL                                    ← existing
```

Closes #34