### PR TITLE
Fix: Correct WebSocket sessionId parsing for multi-segment BASE_PATH

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -60,7 +60,7 @@ const handleUpgrade = (request, socket, head) => {
   const wsPath = basePath ? `${basePath}/ws/` : '/ws/'
   if (pathname.startsWith(wsPath)) {
     const pathParts = pathname.split('/')
-    const sessionId = basePath ? pathParts[3] : pathParts[2]
+    const sessionId = pathParts[pathParts.length - 1]
     const server = wssMap.get(sessionId)
     if (server) {
       server.handleUpgrade(request, socket, head, (ws) => {


### PR DESCRIPTION
Hi,

This PR fixes an issue in the `handleUpgrade` function where `sessionId` is incorrectly extracted when `BASE_PATH` contains multiple path segments.

## The Problem

Currently, the session ID is determined using:

```js
const sessionId = basePath ? pathParts[3] : pathParts[2]
```

This logic assumes:

- `BASE_PATH` has only one segment (e.g. `/whatsapp`)
- Or no base path at all

However, when `BASE_PATH` contains multiple segments, such as:
```env
BASE_PATH=/api/v1/whatsapp
```
The resulting WebSocket path is `/api/v1/whatsapp/ws/{sessionId}` which produces
```js
[
  "",
  "api",
  "v1",
  "whatsapp",
  "ws",
  "{sessionId}"
]
```
In this case, `pathParts[3]` resolves to `"whatsapp"` instead of the actual session ID.

As a result:
- `wssMap.get(sessionId)` fails
- The socket is destroyed
- Reverse Proxies (e.g., Traefik) return `502 Bad Gateway`

## The Solution
Since the session ID is always the final segment of the path, it is safer to dynamically select the last element using this 
```js
const sessionId = pathParts[pathParts.length - 1]
```

This approach:
- Works regardless of `BASE_PATH` depth
- Prevents incorrect session resolution
- Fixes WebSocket upgrade failures behind reverse proxies
- Maintains backward compatibility