### PR TITLE
Fix API change window.store removal in fetchMessages 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -109,7 +109,8 @@ const patchWWebLibrary = async (client) => {
 
       if (searchOptions && searchOptions.limit > 0) {
         while (msgs.length < searchOptions.limit) {
-          const loadedMessages = await window.Store.ConversationMsgs.loadEarlierMsgs(chat)
+          const loadedMessages = await (window.require('WAWebChatLoadMessages')).loadEarlierMsgs(chat);
+
           if (!loadedMessages || !loadedMessages.length) break
           msgs = [...loadedMessages.filter(msgFilter), ...msgs]
         }


### PR DESCRIPTION
window.Store was removed from whatsapp web. This piece of code was using it still. I was now getting hit with it once #104 was merged, although I'm not sure why I wasn't earlier.

This might be a bigger issue that needs addressing here, or something that depends on whatsapp web js version