### PR TITLE
Replace window.Store in utils.getChats

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -140,7 +140,7 @@ const patchWWebLibrary = async (client) => {
         return true
       }
 
-      const allChats = window.Store.Chat.getModelsArray()
+      const allChats = window.require('WAWebCollections').Chat.getModelsArray()
 
       const filteredChats = allChats.filter(chatFilter)
 


### PR DESCRIPTION
This fixes #116 by adhering to the newer whatsapp-web.js interface and using 'window.require' instead of 'window.store'

This fix works for me.