### PR TITLE
Fix message/reply endpoint with a @lid contactId

### DIFF
--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -519,7 +519,10 @@ const reply = async (req, res) => {
         break
       }
       case 'Contact': {
-        const contactId = content.contactId.endsWith('@c.us') ? content.contactId : `${content.contactId}@c.us`
+        const contactId =
+          content.contactId.endsWith('@c.us') || content.contactId.endsWith('@lid')
+            ? content.contactId
+            : `${content.contactId}@c.us`;
         contentMessage = await client.getContactById(contactId)
         break
       }


### PR DESCRIPTION
Avoid adding a contactId '@c.us' postfix if a '@lid' postfix exists, to support @lid ids as well