### PR TITLE
Allow exception details when sending error

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,13 @@ const triggerWebhook = (webhookURL, sessionId, dataType, data) => {
 
 // Function to send a response with error status and message
 const sendErrorResponse = (res, status, message) => {
-  res.status(status).json({ success: false, error: message })
+  var resp = { success: false, error: message }
+  if (message.stack) resp.stack = message.stack;
+  if (message.name) resp.name = message.name;
+  if (message.fileName) resp.fileName = message.fileName;
+  if (message.lineNumber) resp.lineNumber = message.lineNumber;
+
+  res.status(status).json(resp)
 }
 
 // Function to wait for a specific item not to be null


### PR DESCRIPTION
This change allows calling sendErrorResponse with an exception (instead of a string) to include exception details within the returned error. This helps in debugging issues, while currently keeping the existing behavior with no change.

Ideally replacing message in calls to sendErrorResponse with the exception object will make error responses easier to understand.

Exposing the additional details may be a bit insecure, so it's smarted to control with a debug flag.