### PR TITLE
fix: restore message payload and chat lookups on WA Web builds that renamed _serialized

### DIFF
--- a/src/sessions.js
+++ b/src/sessions.js
@@ -183,8 +183,14 @@ const setupSession = async (sessionId) => {
     }
 
     try {
-      client.once('ready', () => {
-        patchWWebLibrary(client).catch((err) => {
+      // `ready` fires again every time the page reloads and the library re-injects itself, not
+      // just once per session. The in-page half of the patch lives on the page's own prototypes,
+      // so a reload wipes it - and with `once` it was never put back. In production the patch went
+      // stale roughly a day after each session start, which is exactly when `sendMessage` began
+      // handing back nothing. Re-run it on every `ready`; `patchSerializedIds` is idempotent and
+      // reports `already applied` when the page still carries it.
+      client.on('ready', () => {
+        patchWWebLibrary(client, sessionId).catch((err) => {
           logger.error({ sessionId, err }, 'Failed to patch WWebJS library')
         })
       })

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,8 +80,133 @@ const exposeFunctionIfAbsent = async (page, name, fn) => {
   await page.exposeFunction(name, fn)
 }
 
+// WhatsApp Web 2.3000.x builds (rolled out since July 2026) minify the serialized id field of
+// Wid/MsgKey objects away from `_serialized` - `$1` in the builds reported upstream. Every
+// `id._serialized` read then yields undefined: WWebJS.sendMessage ends with `Msg.get(undefined)`
+// and returns nothing, so `client.sendMessage()` resolves to undefined and this API answers
+// `{ success: true }` without the message. The same rename strips ids from the message, chat and
+// contact payloads and from the webhooks.
+// Upstream issue: https://github.com/wwebjs/whatsapp-web.js/issues/201830
+// Wid and MsgKey are renamed independently and the alias is minifier output, so each class is
+// probed on its own and the alias is discovered by value rather than assumed to be named `$1`.
+// NOTE: the callback is serialized and evaluated in the browser - it must not reference module scope.
+const patchSerializedIds = async (client) => {
+  return await client.pupPage.evaluate(() => {
+    if (window.__wwebjsApiSerializedIds) {
+      return { applied: false, reason: 'already applied' }
+    }
+
+    // The alias holds the same value `_serialized` used to hold, so the probe finds it by
+    // recognising the serialized value instead of relying on a name the minifier picked.
+    const findAlias = (probe, isSerialized) => {
+      const names = Object.keys(probe).concat(Object.getOwnPropertyNames(Object.getPrototypeOf(probe) || {}))
+      for (const name of names) {
+        if (name === '_serialized' || name === 'constructor') { continue }
+        let value
+        try { value = probe[name] } catch (error) { continue }
+        if (typeof value === 'string' && isSerialized(value)) { return name }
+      }
+      return null
+    }
+
+    const defineSerialized = (prototype, alias) => {
+      Object.defineProperty(prototype, '_serialized', {
+        configurable: true,
+        get () { return this[alias] },
+        set (value) {
+          Object.defineProperty(this, '_serialized', { value, writable: true, enumerable: true, configurable: true })
+        }
+      })
+    }
+
+    // Returns what happened to one class, so a build that renamed only one of them is visible
+    const restoreClass = (buildProbe, isSerialized) => {
+      let probe
+      try {
+        probe = buildProbe()
+      } catch (error) {
+        return { patched: false, reason: `unable to probe: ${error.message}` }
+      }
+      if (typeof probe._serialized === 'string') {
+        return { patched: false, reason: 'exposes _serialized' }
+      }
+      const alias = findAlias(probe, isSerialized)
+      if (!alias) {
+        return { patched: false, reason: 'no _serialized and no alias found' }
+      }
+      const prototype = Object.getPrototypeOf(probe)
+      if (!prototype || Object.getOwnPropertyDescriptor(prototype, '_serialized')) {
+        return { patched: false, reason: 'prototype is not patchable' }
+      }
+      defineSerialized(prototype, alias)
+      return { patched: true, alias }
+    }
+
+    const createWid = (jid) => window.require('WAWebWidFactory').createWid(jid)
+    const wid = restoreClass(
+      () => createWid('0@c.us'),
+      (value) => value === '0@c.us'
+    )
+    // The probe id is also the value of the key's own `id` field, so the serialized one is the
+    // field that carries the id inside a longer string
+    const msgKey = restoreClass(
+      () => {
+        const MsgKey = window.require('WAWebMsgKey')
+        return new MsgKey({ from: createWid('0@c.us'), to: createWid('0@c.us'), id: 'WWEBJSAPIPROBE', selfDir: 'out' })
+      },
+      (value) => value.includes('WWEBJSAPIPROBE') && value.length > 'WWEBJSAPIPROBE'.length
+    )
+
+    const aliases = [wid.alias, msgKey.alias].filter(Boolean)
+    if (!aliases.length) {
+      return { applied: false, reason: 'nothing to restore', wid, msgKey }
+    }
+
+    // Models are plain copies handed over to node, so they need the field set explicitly
+    const restoreSerialized = (value, depth) => {
+      if (!value || typeof value !== 'object' || depth > 6) { return value }
+      if (Array.isArray(value)) {
+        for (const item of value) { restoreSerialized(item, depth + 1) }
+        return value
+      }
+      if (typeof value._serialized !== 'string') {
+        for (const alias of aliases) {
+          if (typeof value[alias] === 'string') {
+            value._serialized = value[alias]
+            break
+          }
+        }
+      }
+      for (const key of Object.keys(value)) { restoreSerialized(value[key], depth + 1) }
+      return value
+    }
+
+    const models = []
+    for (const name of ['getMessageModel', 'getChatModel', 'getContactModel']) {
+      const getModel = window.WWebJS[name]
+      if (typeof getModel !== 'function') { continue }
+      window.WWebJS[name] = function (...args) {
+        const model = getModel.apply(this, args)
+        return model instanceof Promise
+          ? model.then((resolved) => restoreSerialized(resolved, 0))
+          : restoreSerialized(model, 0)
+      }
+      models.push(name)
+    }
+
+    window.__wwebjsApiSerializedIds = true
+    return { applied: true, wid, msgKey, models }
+  })
+}
+
 const patchWWebLibrary = async (client) => {
   // MUST be run after the 'ready' event fired
+  try {
+    logger.info(await patchSerializedIds(client), 'Serialized id patch')
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to patch serialized ids')
+  }
+
   Client.prototype.getChats = async function (searchOptions = {}) {
     const chats = await this.pupPage.evaluate(async (searchOptions) => {
       return await window.WWebJS.getChats({ ...searchOptions })
@@ -164,5 +289,6 @@ module.exports = {
   decodeBase64,
   sleep,
   exposeFunctionIfAbsent,
+  patchSerializedIds,
   patchWWebLibrary
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -199,12 +199,12 @@ const patchSerializedIds = async (client) => {
   })
 }
 
-const patchWWebLibrary = async (client) => {
+const patchWWebLibrary = async (client, sessionId) => {
   // MUST be run after the 'ready' event fired
   try {
-    logger.info(await patchSerializedIds(client), 'Serialized id patch')
+    logger.info({ sessionId, ...await patchSerializedIds(client) }, 'Serialized id patch')
   } catch (error) {
-    logger.error({ err: error }, 'Failed to patch serialized ids')
+    logger.error({ sessionId, err: error }, 'Failed to patch serialized ids')
   }
 
   Client.prototype.getChats = async function (searchOptions = {}) {

--- a/tests/serializedIdPatch.test.js
+++ b/tests/serializedIdPatch.test.js
@@ -1,0 +1,152 @@
+const { patchSerializedIds } = require('../src/utils')
+
+// Builds a stand-in for the WhatsApp Web page context. `widField` and `msgKeyField` name the
+// property each class exposes its serialized id under: `_serialized` on healthy builds, and a
+// minified alias such as `$1` on the builds that renamed it. The two classes are independent -
+// a build can rename one and leave the other alone.
+const createFakeWindow = ({ widField = '_serialized', msgKeyField = '_serialized' } = {}) => {
+  class Wid {
+    constructor (jid) {
+      const [user, server] = jid.split('@')
+      this.user = user
+      this.server = server
+      this[widField] = jid
+    }
+  }
+
+  class MsgKey {
+    constructor ({ from, to, id, selfDir }) {
+      this.fromMe = selfDir === 'out'
+      this.remote = to
+      this.id = id
+      this.self = selfDir
+      this[msgKeyField] = `${this.fromMe}_${to[widField]}_${id}_${selfDir}`
+    }
+  }
+
+  const modules = {
+    WAWebWidFactory: { createWid: (jid) => new Wid(jid) },
+    WAWebMsgKey: MsgKey
+  }
+
+  return {
+    Wid,
+    MsgKey,
+    require: (name) => {
+      if (!modules[name]) { throw new Error(`module ${name} is not available`) }
+      return modules[name]
+    },
+    WWebJS: {
+      getMessageModel: (message) => ({ ...message }),
+      getChatModel: async (chat) => ({ ...chat }),
+      getContactModel: (contact) => ({ ...contact })
+    }
+  }
+}
+
+const createFakeClient = (fakeWindow) => ({
+  pupPage: {
+    evaluate: async (pageFunction, ...args) => {
+      global.window = fakeWindow
+      try {
+        return await pageFunction(...args)
+      } finally {
+        delete global.window
+      }
+    }
+  }
+})
+
+const newMsgKey = (fakeWindow) => new fakeWindow.MsgKey({
+  from: fakeWindow.require('WAWebWidFactory').createWid('1@c.us'),
+  to: fakeWindow.require('WAWebWidFactory').createWid('123@c.us'),
+  id: 'ABCD',
+  selfDir: 'out'
+})
+
+describe('patchSerializedIds', () => {
+  it('restores _serialized on both classes when the build renamed both', async () => {
+    const fakeWindow = createFakeWindow({ widField: '$1', msgKeyField: '$1' })
+
+    const result = await patchSerializedIds(createFakeClient(fakeWindow))
+
+    expect(result.applied).toBe(true)
+    expect(result.wid).toEqual({ patched: true, alias: '$1' })
+    expect(result.msgKey).toEqual({ patched: true, alias: '$1' })
+    expect(fakeWindow.require('WAWebWidFactory').createWid('123@c.us')._serialized).toBe('123@c.us')
+    expect(newMsgKey(fakeWindow)._serialized).toBe('true_123@c.us_ABCD_out')
+  })
+
+  // The case that reached production: the wid probe found a healthy `_serialized` and the
+  // original patch bailed out before it ever looked at MsgKey, which is the class sendMessage
+  // needs to find the message it has just sent.
+  it('patches MsgKey even when Wid still exposes _serialized', async () => {
+    const fakeWindow = createFakeWindow({ widField: '_serialized', msgKeyField: '$1' })
+
+    const result = await patchSerializedIds(createFakeClient(fakeWindow))
+
+    expect(result.applied).toBe(true)
+    expect(result.wid).toEqual({ patched: false, reason: 'exposes _serialized' })
+    expect(result.msgKey).toEqual({ patched: true, alias: '$1' })
+    expect(newMsgKey(fakeWindow)._serialized).toBe('true_123@c.us_ABCD_out')
+  })
+
+  // `$1` is minifier output, so the index is not something to rely on across builds.
+  it('finds the alias whatever it is named', async () => {
+    const fakeWindow = createFakeWindow({ widField: '$7', msgKeyField: '$4' })
+
+    const result = await patchSerializedIds(createFakeClient(fakeWindow))
+
+    expect(result.wid).toEqual({ patched: true, alias: '$7' })
+    expect(result.msgKey).toEqual({ patched: true, alias: '$4' })
+    expect(newMsgKey(fakeWindow)._serialized).toBe('true_123@c.us_ABCD_out')
+  })
+
+  it('leaves a healthy build untouched', async () => {
+    const fakeWindow = createFakeWindow()
+    const getMessageModel = fakeWindow.WWebJS.getMessageModel
+
+    const result = await patchSerializedIds(createFakeClient(fakeWindow))
+
+    expect(result.applied).toBe(false)
+    expect(result.wid).toEqual({ patched: false, reason: 'exposes _serialized' })
+    expect(result.msgKey).toEqual({ patched: false, reason: 'exposes _serialized' })
+    expect(fakeWindow.WWebJS.getMessageModel).toBe(getMessageModel)
+    expect(Object.getOwnPropertyDescriptor(fakeWindow.Wid.prototype, '_serialized')).toBeUndefined()
+    expect(Object.getOwnPropertyDescriptor(fakeWindow.MsgKey.prototype, '_serialized')).toBeUndefined()
+  })
+
+  describe('once an alias was found', () => {
+    let fakeWindow
+
+    beforeEach(async () => {
+      fakeWindow = createFakeWindow({ widField: '$1', msgKeyField: '$1' })
+      await patchSerializedIds(createFakeClient(fakeWindow))
+    })
+
+    it('keeps _serialized writable', () => {
+      const wid = fakeWindow.require('WAWebWidFactory').createWid('123@c.us')
+      wid._serialized = '456@c.us'
+      expect(wid._serialized).toBe('456@c.us')
+    })
+
+    it('restores _serialized on the plain ids returned by the model getters', async () => {
+      const model = fakeWindow.WWebJS.getMessageModel({
+        id: { fromMe: true, remote: '123@c.us', id: 'ABCD', $1: 'true_123@c.us_ABCD_out' },
+        body: 'hello'
+      })
+      expect(model.id._serialized).toBe('true_123@c.us_ABCD_out')
+
+      const chat = await fakeWindow.WWebJS.getChatModel({ id: { user: '123', server: 'c.us', $1: '123@c.us' } })
+      expect(chat.id._serialized).toBe('123@c.us')
+    })
+
+    it('does not apply twice', async () => {
+      const wrapped = fakeWindow.WWebJS.getMessageModel
+      const result = await patchSerializedIds(createFakeClient(fakeWindow))
+      expect(result.applied).toBe(false)
+      expect(result.reason).toBe('already applied')
+      expect(fakeWindow.WWebJS.getMessageModel).toBe(wrapped)
+    })
+  })
+})

--- a/tests/serializedIdPatch.test.js
+++ b/tests/serializedIdPatch.test.js
@@ -141,6 +141,20 @@ describe('patchSerializedIds', () => {
       expect(chat.id._serialized).toBe('123@c.us')
     })
 
+    it('applies again after the page reloaded and dropped the patch', async () => {
+      // `ready` fires again on every reload, and the page comes back without the prototype
+      // getter. In production the patch went stale about a day into each session and
+      // `Msg.get(key._serialized)` started missing for every message the library had just sent.
+      const reloaded = createFakeWindow({ widField: '$1', msgKeyField: '$1' })
+      const result = await patchSerializedIds(createFakeClient(reloaded))
+
+      expect(result.applied).toBe(true)
+      const wid = reloaded.require('WAWebWidFactory').createWid('123@c.us')
+      const key = new (reloaded.require('WAWebMsgKey'))({ from: wid, to: wid, id: 'ABCD', selfDir: 'out' })
+      // this is the read whatsapp-web.js does on the message it has just sent
+      expect(key._serialized).toBe('true_123@c.us_ABCD_out')
+    })
+
     it('does not apply twice', async () => {
       const wrapped = fakeWindow.WWebJS.getMessageModel
       const result = await patchSerializedIds(createFakeClient(fakeWindow))


### PR DESCRIPTION
## The problem

WhatsApp Web 2.3000.x ships minified and renames `_serialized` on its id classes to whatever the minifier picked — currently `$1`. Every id the API hands back loses `_serialized`, so message payloads, chat lookups and the library's own internal `Msg.get(key._serialized)` all break.

The rename is per class. On the build I am looking at, `Wid` still exposes `_serialized` and `MsgKey` does not — so probing one and assuming the other is wrong.

## What this does

`patchSerializedIds` builds a throwaway instance of each class with a known id, then finds the field **by value** — the one holding the string the serialized id should be. Never by name, because the name is whatever the minifier picked this build. It then installs a `_serialized` getter on that prototype, and reports per class what happened:

```json
{"applied": true,
 "wid":    {"patched": false, "reason": "exposes _serialized"},
 "msgKey": {"patched": true,  "alias": "$1"},
 "models": ["getMessageModel", "getChatModel", "getContactModel"]}
```

Because the getter sits on the prototype, it also fixes the reads whatsapp-web.js does inside its own injected code — including `Msg.get(newMsgKey._serialized)` on a message it has just sent.

## `ready` is not a one-shot event

The second commit is the one that makes this hold up over time, and it took production to find.

whatsapp-web.js emits `ready` from `onAppStateHasSyncedEvent`, which WhatsApp Web calls again on every reconnect — and the library explicitly re-injects `window.WWebJS` when it finds the page came back without it. This patch lives on the page's own prototypes, so a reload wipes it, and `client.once('ready', ...)` never put it back.

In production the patch went stale roughly a day into each session. That is exactly when `sendMessage` started handing back nothing: with the getter gone, the lookup on the just-sent message missed, and the library returned undefined for a message that had in fact been delivered.

The guard flag lives on the page too, so re-running reports `already applied` while the page still carries the patch, and re-applies once it does not. The patch result now logs its sessionId — two sessions produced a single patch line with no way to tell which one it was.

## Testing

`tests/serializedIdPatch.test.js` against a fake page: each class renamed independently, `_serialized` still writable, models restored, no double application, and a reloaded page getting patched again.

```
npm test  → 47 passed
npx eslint src tests
```

Running in production since 2026-08-19.