### PR TITLE
fix: report the missing message instead of failing a delivered send

### DIFF
--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -136,7 +136,11 @@ const sendMessage = async (req, res) => {
         return sendErrorResponse(res, 400, 'invalid contentType')
     }
     if (!messageOut) {
-      return sendErrorResponse(res, 500, 'whatsapp-web.js did not return the sent message')
+      return res.json({
+        success: true,
+        message: null,
+        warning: 'whatsapp-web.js did not return the sent message; it may still have been delivered'
+      })
     }
     res.json({ success: true, message: messageOut })
   } catch (error) {

--- a/src/controllers/channelController.js
+++ b/src/controllers/channelController.js
@@ -135,6 +135,9 @@ const sendMessage = async (req, res) => {
       default:
         return sendErrorResponse(res, 400, 'invalid contentType')
     }
+    if (!messageOut) {
+      return sendErrorResponse(res, 500, 'whatsapp-web.js did not return the sent message')
+    }
     res.json({ success: true, message: messageOut })
   } catch (error) {
     sendErrorResponse(res, 500, error)

--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -1,6 +1,6 @@
 const { MessageMedia, Location, Poll } = require('whatsapp-web.js')
 const { sessions } = require('../sessions')
-const { sendErrorResponse } = require('../utils')
+const { sendErrorResponse, logMissingMessage } = require('../utils')
 
 /**
  * Send a message to a chat using the WhatsApp API
@@ -108,6 +108,13 @@ const sendMessage = async (req, res) => {
       }
       default:
         return sendErrorResponse(res, 400, 'invalid contentType')
+    }
+    // Callers keep the returned id to correlate the message later on, so a success without a
+    // message would leave them dereferencing undefined. The library returns nothing when it
+    // refuses to send the content, which is a failure and has to be reported as one.
+    if (!messageOut) {
+      await logMissingMessage(client, chatId)
+      return sendErrorResponse(res, 500, 'whatsapp-web.js did not return the sent message')
     }
     res.json({ success: true, message: messageOut })
   } catch (error) {

--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -109,12 +109,17 @@ const sendMessage = async (req, res) => {
       default:
         return sendErrorResponse(res, 400, 'invalid contentType')
     }
-    // Callers keep the returned id to correlate the message later on, so a success without a
-    // message would leave them dereferencing undefined. The library returns nothing when it
-    // refuses to send the content, which is a failure and has to be reported as one.
+    // The library looks the message up only after it has already handed it to the chat, so
+    // nothing coming back does not mean nothing was sent - answering 500 here would invite the
+    // caller to retry a message the contact has already received. Say plainly that the message
+    // is missing instead, and report what the page looked like so the cause is not guesswork.
     if (!messageOut) {
       await logMissingMessage(client, chatId)
-      return sendErrorResponse(res, 500, 'whatsapp-web.js did not return the sent message')
+      return res.json({
+        success: true,
+        message: null,
+        warning: 'whatsapp-web.js did not return the sent message; it may still have been delivered'
+      })
     }
     res.json({ success: true, message: messageOut })
   } catch (error) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,50 @@ const exposeFunctionIfAbsent = async (page, name, fn) => {
   await page.exposeFunction(name, fn)
 }
 
+// Called when the library sends a message but hands nothing back. Reports what the page looks
+// like at that moment so the failure can be told apart from a plain rename: whether a fresh
+// MsgKey exposes `_serialized`, and how the keys of the messages already in the chat are shaped.
+const logMissingMessage = async (client, chatId) => {
+  try {
+    const snapshot = await client.pupPage.evaluate(async (chatId) => {
+      const probe = (() => {
+        try {
+          const MsgKey = window.require('WAWebMsgKey')
+          const wid = window.require('WAWebWidFactory').createWid('0@c.us')
+          const key = new MsgKey({ from: wid, to: wid, id: 'WWEBJSAPIPROBE', selfDir: 'out' })
+          return { serialized: key._serialized, fields: Object.keys(key) }
+        } catch (error) {
+          return { error: error.message }
+        }
+      })()
+
+      const lastOutgoing = await (async () => {
+        try {
+          const chat = await window.WWebJS.getChat(chatId, { getAsModel: false })
+          const msgs = (chat && chat.msgs && chat.msgs.getModelsArray()) || []
+          for (let i = msgs.length - 1; i >= 0; i--) {
+            const id = msgs[i] && msgs[i].id
+            if (!id || !id.fromMe) { continue }
+            return {
+              serialized: id._serialized,
+              fields: Object.keys(id),
+              foundInCollection: !!window.require('WAWebCollections').Msg.get(id._serialized)
+            }
+          }
+          return { error: 'no outgoing message in this chat' }
+        } catch (error) {
+          return { error: error.message }
+        }
+      })()
+
+      return { waVersion: window.Debug && window.Debug.VERSION, probe, lastOutgoing }
+    }, chatId)
+    logger.warn({ chatId, ...snapshot }, 'Sent message was not returned by the library')
+  } catch (error) {
+    logger.warn({ chatId, err: error }, 'Sent message was not returned by the library')
+  }
+}
+
 const patchWWebLibrary = async (client) => {
   // MUST be run after the 'ready' event fired
   Client.prototype.getChats = async function (searchOptions = {}) {
@@ -164,5 +208,6 @@ module.exports = {
   decodeBase64,
   sleep,
   exposeFunctionIfAbsent,
+  logMissingMessage,
   patchWWebLibrary
 }

--- a/tests/sendMessageContract.test.js
+++ b/tests/sendMessageContract.test.js
@@ -1,0 +1,90 @@
+jest.mock('../src/sessions', () => ({ sessions: new Map() }))
+
+const { sessions } = require('../src/sessions')
+const { sendMessage } = require('../src/controllers/clientController')
+const { sendMessage: sendChannelMessage } = require('../src/controllers/channelController')
+
+const createResponse = () => {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status (code) {
+      this.statusCode = code
+      return this
+    },
+    json (body) {
+      this.body = body
+      return this
+    }
+  }
+  return res
+}
+
+const createRequest = (client) => {
+  sessions.set('test', client)
+  return {
+    params: { sessionId: 'test' },
+    body: { chatId: '123@c.us', contentType: 'string', content: 'Hello World!' }
+  }
+}
+
+const sentMessage = { id: { id: 'ABCD', _serialized: 'true_123@c.us_ABCD' }, body: 'Hello World!' }
+
+afterEach(() => sessions.clear())
+
+// Clients keep the returned id to correlate the message later on, so a 200 that carries no
+// message leaves them dereferencing undefined. Anything the library refuses to send has to
+// come back as an error instead.
+describe('POST /client/sendMessage', () => {
+  it('returns the sent message', async () => {
+    const req = createRequest({ sendMessage: async () => sentMessage })
+    const res = createResponse()
+
+    await sendMessage(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ success: true, message: sentMessage })
+  })
+
+  it('fails instead of answering 200 without a message', async () => {
+    const req = createRequest({ sendMessage: async () => undefined })
+    const res = createResponse()
+
+    await sendMessage(req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body.success).toBe(false)
+    expect(res.body.error).toMatch(/did not return the sent message/)
+  })
+})
+
+describe('POST /channel/sendMessage', () => {
+  const createChannelRequest = (chat) => {
+    sessions.set('test', { getChatById: async () => chat })
+    return {
+      params: { sessionId: 'test' },
+      body: { chatId: '123@newsletter', contentType: 'string', content: 'Hello World!' }
+    }
+  }
+
+  it('returns the sent message', async () => {
+    const req = createChannelRequest({ isChannel: true, sendMessage: async () => sentMessage })
+    const res = createResponse()
+
+    await sendChannelMessage(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ success: true, message: sentMessage })
+  })
+
+  it('fails instead of answering 200 without a message', async () => {
+    const req = createChannelRequest({ isChannel: true, sendMessage: async () => null })
+    const res = createResponse()
+
+    await sendChannelMessage(req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body.success).toBe(false)
+    expect(res.body.error).toMatch(/did not return the sent message/)
+  })
+})

--- a/tests/sendMessageContract.test.js
+++ b/tests/sendMessageContract.test.js
@@ -46,15 +46,17 @@ describe('POST /client/sendMessage', () => {
     expect(res.body).toEqual({ success: true, message: sentMessage })
   })
 
-  it('fails instead of answering 200 without a message', async () => {
+  it('says the message is missing instead of pretending it is there', async () => {
     const req = createRequest({ sendMessage: async () => undefined })
     const res = createResponse()
 
     await sendMessage(req, res)
 
-    expect(res.statusCode).toBe(500)
-    expect(res.body.success).toBe(false)
-    expect(res.body.error).toMatch(/did not return the sent message/)
+    // not a 500: the library looks the message up only after handing it to the chat, so a retry
+    // would send the contact a second copy of something they already have
+    expect(res.statusCode).toBe(200)
+    expect(res.body.message).toBeNull()
+    expect(res.body.warning).toMatch(/did not return the sent message/)
   })
 })
 
@@ -77,14 +79,14 @@ describe('POST /channel/sendMessage', () => {
     expect(res.body).toEqual({ success: true, message: sentMessage })
   })
 
-  it('fails instead of answering 200 without a message', async () => {
+  it('says the message is missing instead of pretending it is there', async () => {
     const req = createChannelRequest({ isChannel: true, sendMessage: async () => null })
     const res = createResponse()
 
     await sendChannelMessage(req, res)
 
-    expect(res.statusCode).toBe(500)
-    expect(res.body.success).toBe(false)
-    expect(res.body.error).toMatch(/did not return the sent message/)
+    expect(res.statusCode).toBe(200)
+    expect(res.body.message).toBeNull()
+    expect(res.body.warning).toMatch(/did not return the sent message/)
   })
 })


### PR DESCRIPTION
## The problem

`POST /client/sendMessage` can answer `{"success": true}` with no `message` at all. Callers keep the returned id to correlate the message later, so a success with nothing in it leaves them dereferencing undefined.

## Why this is not a 500

My first version of this PR answered 500. That was wrong, and worth spelling out.

`window.WWebJS.sendMessage` hands the message to the chat and awaits it, and only *then* looks it up — `src/util/Injected/Utils.js`:

```js
const [msgPromise, sendMsgResultPromise] = window
  .require('WAWebSendMsgChatAction')
  .addAndSendMsgToChat(chat, message);
await msgPromise;                                  // the message is already on its way

return window.require('WAWebCollections')
  .Msg.get(newMsgKey._serialized);                 // and only now do we look for it
```

So a lookup that misses says nothing about whether the contact received the message. On WhatsApp Web 2.3000.x, which no longer exposes `_serialized` on `MsgKey`, it misses on **every** send — and a caller that retries on 500 delivers a second copy of something the contact already has.

## What it does now

Answer 200 with an explicit `message: null` and a warning:

```json
{
  "success": true,
  "message": null,
  "warning": "whatsapp-web.js did not return the sent message; it may still have been delivered"
}
```

The caller still learns it has no id to correlate on — which is what the silent `{"success": true}` failed to tell it — but nothing invites a retry. Same treatment in `channelController`.

`logMissingMessage` stays. It reports what the page looked like at that moment — whether a fresh `MsgKey` exposes `_serialized`, and how the keys of the messages already in the chat are shaped. That is what identified the cause in the first place.

## Related

#150 removes the common cause: the `_serialized` getter it installs is what makes that `Msg.get` hit, and it now survives page reloads. With that in, this path should be rare — but the response shape should still not lie either way.

## Testing

```
npm test  → 43 passed
npx eslint src tests
```